### PR TITLE
Added ease of use prerenderer and adhered the code to somewhat of the "standard" that most plugins use

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A simple script and sample stylesheet for using accordions in Docsify!
 3. Indicate which headers you'd like to accordify by adding " +" to the end, like this:
 
 ```markdown
-## My great accordion
+## My great accordion +
 
 Peekaboo!
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A simple script and sample stylesheet for using accordions in Docsify!
 Peekaboo!
 ```
 
-5. Enjoy!
+4. Enjoy!
 
 ### Comments-Pre Parser
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,115 @@
 
 A simple script and sample stylesheet for using accordions in Docsify!
 
+> If you are here because of a warning in your console, or because of a deprecated `loadAccordions`, go to [update](#Update) 
+
 ## How to Use
+
+1. Insert this script at the end of the document:
+
+```html
+<script src="//unpkg.com/docsify-accordify/src/index.js"></script>
+```
+
+2. Create a custom stylesheet or use a default one:
+
+```html
+<link rel="stylesheet" href="//unpkg.com/docsify-accordify/src/assets/default.css">
+```
+
+3. Indicate which headers you'd like to accordify by adding " +" to the end, like this:
+
+```markdown
+## My great accordion
+
+Peekaboo!
+```
+
+5. Enjoy!
+
+### Comments-Pre Parser
+
+Accordify can pre-parse comments and include whole files into the body of an accordion. Let's say, you want to render a custom md file called "foo.md" and add it into an accordion. Then you can add the comment `<!-- accordify-inline:<filename> -->` to your markdown file:
+
+```markdown
+# Some Header
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+
+<!-- accordify-inline:foo.md -->
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+```
+
+The prenderer will take this and convert the comment into the following
+
+```markdown
+# Some Header
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+
+## foo.md + 
+
+[foo.md](foo.md ':include')
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+```
+
+As you can see, the comment has been translated into an accordion and we use the default ':include' syntax from docsiy.
+
+#### Custom Title
+
+The name of the accordion can be changed, py providing a "second argument" to the comment, like this: `<!-- accordify-inline:<filename>|<title> -->`
+
+So if you want the Title to be "Foo-Bar, the great journey of the Baz", you can to it like this:
+
+```markdown
+<!-- accordify-inline:foo.md|Foo-Bar, the great journey of the Baz -->
+```
+
+Which will be pre rendered to
+
+```markdown
+## Foo-Bar, the great journey of the Baz +
+
+[foo.md](foo.md ':include')
+```
+
+### Configurations
+
+Accordify allows you to enable or disable certain parts. This is the current configuration with default values provided:
+
+```javascript
+window.$docsify = {
+    accordify: {
+        prerenderComments: true,                    // default
+        selectors: ['h1','h2','h3','h4','h5','h6'], // default value
+        debug: false,                               // default value
+    }
+}
+```
+
+- **prerenderComments [boolean]:** If false, accordify comments will not be pre rendered
+- **selectors [Array<String>]:** List of all selectors that should be respected for accordions (must be findable by `document.querySelectorAll`)
+- **debug [boolean]:** If true, some debug statements will be printed
+
+You do not need to add these comments, if you do not want to change them
+
+## Update
+
+If you have seen the warning
+
+```
+You are using an outdated version of Accordify. Please checkout the github page for further information.
+```
+
+You may want to do the following:
+
+1) Move the link to the script to the bottom (under the declaration of `window.$docsify = { ... }`)
+2) Remove the explicit plugin `window.$docsify.plugins: [ loadAccordions, ... ]`
+3) Done! Now you are up to speed!
+
+## How to Use (The old way)
 
 1. Configure docsify-accordify:
 

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -1,0 +1,56 @@
+.accordion {
+    background-color: #eee;
+    color: #ccc;
+    cursor: pointer;
+    padding: 18px;
+    width: 100%;
+    text-align: left;
+    border: none;
+    outline: none;
+    transition: padding 0s, max-height 0.2s, height 0.2s;
+}
+
+.plus-container {
+    position: absolute;
+    right: 18px;
+    padding-right: 18px;
+}
+
+.plus.opened {
+    display: none;
+}
+.plus-container.opened:before {
+    content: "-"
+}
+
+.accordion.opened {
+    background-color: #ccc;
+}
+.accordion:hover {
+    background-color: #ddd;
+}
+
+.accordion {
+    margin-bottom: 0 !important;
+}
+
+.accordion > a:-webkit-any-link {
+    text-decoration: none;
+}
+
+.panel.opened {
+    transform: scaleY(1);
+    padding: 18px;
+    transition: padding 0s 0s, transform 0.1s 0s ease-in;
+}
+
+.panel {
+    transform: scaleY(0);
+    transform-origin: top;
+    padding: 0;
+
+    overflow: hidden;
+    border: 1px solid #eee;
+    border-top: none;
+    transition: transform 0.1s 0s ease-in, padding 0s 0.1s;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,141 @@
-function loadAccordions(hook, vm) {
-  hook.doneEach(function () {
-    const allHeaders = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+// #########################################################################
+// # Settings and default containers for ease of use (and standardization) #
+// #########################################################################
+/**
+ * Placeholder object for string formatting in pre-render replacement
+ * @type {{file: string, name: string, linkName: string}}
+ */
+const placeholder = {
+    name: "{{name}}",
+    linkName: "{{linkName}}",
+    file: "{{file}}",
+}
 
-    for (let i = 0; i < allHeaders.length; i++) {
-      if (allHeaders[i].firstChild.firstChild.textContent.endsWith(" +")) {
-        allHeaders[i].classList.add('accordion')
+/**
+ * The main object, holding information shared across parts.
+ *
+ * This object exists (and is bound globally) so that configurations can easily be applied
+ *
+ * @type {{regex: RegExp, prefix: string, constructReplacement: (function(*=, *): string), placeholder: {file: string, name: string, linkName: string}, postfix: string, rawReplacement: string, properties: {prerenderComments: boolean}}}
+ */
+const Accordify = {
+    placeholder: placeholder,
+    rawReplacement: "## " + placeholder.name + " + \n\n[" + placeholder.file + "](" + placeholder.file + " ':include')\n[comment]: <> (End of Accordion " + placeholder.name + ")",
+    prefix: "<!-- accordify-inline:",
+    postfix: " -->",
+    regex: new RegExp(`<!-- accordify-inline:.* -->`, "g"),
+    properties: {
+        prerenderComments: true,
+        selectors: ['h1','h2','h3','h4','h5','h6'],
+        debug: false
+    },
+    constructReplacement: (contents, rawReplacement) => {
+        if (!Array.isArray(contents)) {
+            throw Error("typeof " + contents + " does not match " + typeof contents)
+        }
 
-        headerAside = document.querySelector(`a[title='` + allHeaders[i].firstChild.firstChild.textContent + `']`);
-        headerAside.href = headerAside.href.substring(0, headerAside.href.length-1);
-        headerAside.setAttribute('title', headerAside.getAttribute('title').substring(0, headerAside.getAttribute('title').length-2));
-        headerAside.textContent = headerAside.textContent.substring(0, headerAside.textContent.length-2);
+        const file = contents[0]
+        const name = contents.length >= 2 ? contents[1] : contents[0]
 
-        allHeaders[i].id = allHeaders[i].id.substring(0, allHeaders[i].id.length-1);
-        allHeaders[i].firstChild.href = allHeaders[i].firstChild.href.substring(0, allHeaders[i].firstChild.href.length-1);
-        allHeaders[i].firstChild.setAttribute('data-id', allHeaders[i].firstChild.getAttribute('data-id').substring(0, allHeaders[i].firstChild.getAttribute('data-id').length-1));
+        return rawReplacement.replace(placeholder.name, name)
+            .replaceAll(placeholder.file, file)
+    }
+}
 
-        titleSpan = allHeaders[i].firstChild.firstChild;
-        titleSpan.textContent = titleSpan.textContent.substring(0, titleSpan.textContent.length-2)
-        plusSpan = document.createElement('span');
-        plusSpan.textContent = '+';
-        plusSpan.classList = 'plus';
-        titleSpan.insertAdjacentElement('afterend', plusSpan);
-      }
+// #####################################################################
+// # Pre-render comments, pointing to a file into the accordify layout #
+// #####################################################################
+/**
+ * Will prerender comments according to the <!-- accordify-inline:<file><optional: |<title>> --> format
+ *
+ * This method will prerender these comments to adhere to the default schema of an accordion (as described in the documentation).
+ *
+ * Resulting will be an accordion, which inlines a whole different file, like this:
+ *
+ * ```markdown
+ * ## <title || filename> +
+ *
+ * [file](file :'include')
+ * ```
+ *
+ * @param content the raw markdown
+ * @returns {string} the pre rendered markdown, with all respective comments translated to accordions
+ */
+const accordifyInlinePrerender = (content) => {
+    let newContent = content
+    if (newContent.search(Accordify.regex) !== -1) {
+        newContent = newContent.replaceAll(Accordify.regex, substring => {
+            let rawName = substring.replace(Accordify.prefix, "")
+            rawName = rawName.replace(Accordify.postfix, "")
+
+            const nameContents = rawName.split("|")
+
+            if(Accordify.properties.debug) {
+                console.debug("[Prerender] rendering", nameContents)
+            }
+
+            return Accordify.constructReplacement(nameContents, Accordify.rawReplacement)
+        })
+    }
+
+    return newContent;
+}
+
+// #####################################################
+// # Actually translate the markdown entries into html #
+// #####################################################
+/**
+ * Renders the actual accordions
+ */
+const accordifyRenderAccordions = () => {
+    let selected = []
+    Accordify.properties.selectors.forEach(selector => {
+        const found = document.querySelectorAll(selector);
+        found.forEach(header => selected.push(header))
+        if(Accordify.properties.debug) {
+            console.debug("Selector results", selector, found)
+        }
+    })
+
+    let headerAside;
+    let titleSpan;
+    let plusSpan;
+
+    let plusSpanWrapper;
+    for (let i = 0; i < selected.length; i++) {
+        if (selected[i].firstChild.firstChild.textContent.endsWith(" +")) {
+            if(Accordify.properties.debug) {
+                console.debug("Found accordion relevant element (because it ends on \" +\")", selected[i])
+            }
+            selected[i].classList.add('accordion')
+            selected[i].classList.add(Accordify.properties.theme)
+
+            headerAside = document.querySelector(`a[title='` + selected[i].firstChild.firstChild.textContent + `']`);
+            headerAside.href = headerAside.href.substring(0, headerAside.href.length - 1);
+            headerAside.setAttribute('title', headerAside.getAttribute('title').substring(0, headerAside.getAttribute('title').length - 2));
+            headerAside.textContent = headerAside.textContent.substring(0, headerAside.textContent.length - 2);
+
+            selected[i].id = selected[i].id.substring(0, selected[i].id.length - 1);
+            selected[i].firstChild.href = selected[i].firstChild.href.substring(0, selected[i].firstChild.href.length - 1);
+            selected[i].firstChild.setAttribute('data-id', selected[i].firstChild.getAttribute('data-id').substring(0, selected[i].firstChild.getAttribute('data-id').length - 1));
+
+            titleSpan = selected[i].firstChild.firstChild;
+            titleSpan.textContent = titleSpan.textContent.substring(0, titleSpan.textContent.length - 2)
+
+            plusSpan = document.createElement('span');
+            plusSpan.textContent = '+';
+            plusSpan.classList.add('plus');
+            plusSpan.classList.add(Accordify.properties.theme);
+            plusSpan.dataset.opentrigger = "1"
+
+            plusSpanWrapper = document.createElement('span')
+            plusSpanWrapper.classList.add('plus-container');
+            plusSpanWrapper.classList.add(Accordify.properties.theme);
+            plusSpanWrapper.dataset.opentrigger = "1"
+            plusSpanWrapper.appendChild(plusSpan)
+
+            titleSpan.insertAdjacentElement('afterend', plusSpanWrapper);
+        }
     }
 
     const accordions = document.querySelectorAll('.accordion');
@@ -31,40 +145,108 @@ function loadAccordions(hook, vm) {
     let panelContent;
     let panelContents;
 
-    for (i = 0; i < accordions.length; i++) {
-      panelContents = [];
-      currentHeaderType = accordions[i].tagName;
-      panelDiv = document.createElement('div');
-      panelContent = accordions[i];
-      panelDiv.classList.add('panel');
-      while (panelContent) {
-        panelContent = panelContent.nextElementSibling;
-        if (panelContent && panelContent.tagName !== currentHeaderType) {
-          panelContents.push(panelContent);
-        } else {
-          break;
+    for (let i = 0; i < accordions.length; i++) {
+        panelContents = [];
+        currentHeaderType = accordions[i].tagName;
+        panelDiv = document.createElement('div');
+        panelContent = accordions[i];
+        panelDiv.classList.add('panel');
+        panelDiv.classList.add(Accordify.properties.theme);
+        while (panelContent) {
+            panelContent = panelContent.nextElementSibling;
+            if (panelContent && panelContent.tagName !== currentHeaderType) {
+                panelContents.push(panelContent);
+            } else {
+                break;
+            }
         }
-      }
-      for (let j = 0; j < panelContents.length; j++) {
-        console.log(accordions[i])
-        console.log(panelContents[j])
-        panelDiv.append(panelContents[j])
-        console.log(panelDiv)
-      }
-      accordions[i].insertAdjacentElement('afterend', panelDiv);
+        for (let j = 0; j < panelContents.length; j++) {
+            panelDiv.append(panelContents[j])
+        }
+        accordions[i].insertAdjacentElement('afterend', panelDiv);
     }
 
-    for (i = 0; i < accordions.length; i++) {
-      accordions[i].addEventListener("click", function() {
-        this.classList.toggle("opened");
-
-        let panel = this.nextElementSibling;
-        if (panel.style.display === "block") {
-          panel.style.display = "none";
-        } else {
-          panel.style.display = "block";
-        }
-      });
+    if(Accordify.properties.debug) {
+        console.debug("Successfully translated " + accordions.length + " accordions")
     }
-  });
+    for (let i = 0; i < accordions.length; i++) {
+        accordions[i].addEventListener("click", function () {
+            this.classList.toggle("opened");
+
+            this.nextElementSibling.classList.toggle("opened");
+            this.querySelectorAll("[data-opentrigger=\"1\"]").forEach(plusSpan => plusSpan.classList.toggle("opened"))
+        });
+    }
+}
+
+/**
+ * Tries to read and set properties, based on the window.$docsify variable
+ *
+ * The sub-namespace must be accordify.
+ */
+const accordifySetProperties = () => {
+    if (window.$docsify !== undefined && window.$docsify.accordify !== undefined) {
+        const setProperties = window.$docsify.accordify
+        /**
+         * Tries to update a specific property, base on the provided properties.
+         *
+         * This method will also try to ensure type-safety. I.e. the variable type.
+         *
+         * @param name the name of the variable that should be checked for and then potentially overwritten
+         * @param type the expected type of the variable (must be checkable by "typeof")
+         */
+        const setProperty = (name, type) => {
+            if(setProperties[name] !== undefined) {
+                if(typeof setProperties[name] === type) {
+                    Accordify.properties[name] = setProperties[name]
+                } else {
+                    console.warn("IGNORING SET PROPERTY " + name ,
+                        "Found illegal type for the property \"" + name + "\". Expected " + type + " but got " + typeof setProperties[name])
+                }
+            }
+        }
+
+        // Set all the supported properties
+        setProperty("prerenderComments", "boolean")
+        setProperty("debug", "boolean")
+        setProperty("relevantHeaders", "string")
+    }
+}
+
+// #############################################################################
+// # Register the inline prerender and the accordion render action accordingly #
+// #############################################################################
+/**
+ * The main Accordify plugin, that will automatically be passed down to Docsify
+ *
+ * @param hook as the hook container provided by Docsify
+ * @param vm as the vm provided by Docsify
+ */
+const AccordifyPlugin = (hook, vm) => {
+    accordifySetProperties()
+    if (Accordify.properties.prerenderComments) {
+        hook.beforeEach(accordifyInlinePrerender)
+    }
+    hook.doneEach(accordifyRenderAccordions);
+}
+
+// #######################################################################
+// # Only render the accordions (still here for backwards compatibility) #
+// #######################################################################
+/**
+ * @deprecated please refrain from using this. Instead, simply add the source
+ * @param hook
+ * @param vm
+ */
+function loadAccordions(hook, vm) {
+    hook.doneEach(accordifyRenderAccordions)
+}
+
+// ####################################################
+// # Try to automatically register the docsify plugin #
+// ####################################################
+if (window.$docsify && window.$docsify.plugins) {
+    window.$docsify.plugins.push(AccordifyPlugin)
+} else {
+    console.warn("You are using an outdated version of Accordify. Please checkout the github page for further information.")
 }


### PR DESCRIPTION
## Description

Hey! I really like this project. I felt like there is one thing missing, a pre-renderer that automatically include files into accordions, because this use case popped up several times now.

So i Added it!

It can be used the following: Adding this comment includes a file in an accordion:

```html
<!-- accordify-inline:file.md|Optional Header Name -->
```

This is done simply be pre-rendering the markdown and replacing this comment with the default accordion syntax.

I also took the liberty and changed the way this plug-in is added to be more streamline with other plug-ins. I changed some parts, but no major rewrite of the existing code.

Also also, i added some default style that has crystallized to be quite streamline.

## Does it break anything?

I made sure that it is backwards compatible, but i deprecated the old plug-in and added a warning log when the old approach is used, so that more people get to use this feature, if they want to.

## What exactly was done?

The  whole changelog (according to [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)) is now listed. Sorry that the commits are not clean, but i stupidly squashed the commits :/.

# Changelog

### feat!: comment prerender for file inclusion in accordions

This prerenderer is able to render comments and therefore include files in accordions. It is nothing major, but a time-safer.

---

### feat: default style for accordions

---

### docs: described the prerenderer and added some examples

---

### refactor: added a code-based configuration

---

### refactor: made more than just headers selectable

---

### refactor: removed console.log and added conditional debugging